### PR TITLE
Replace `@flaky` decorator with pytest marker

### DIFF
--- a/qtconsole/tests/test_00_console_widget.py
+++ b/qtconsole/tests/test_00_console_widget.py
@@ -2,7 +2,6 @@ import os
 import unittest
 import sys
 
-from flaky import flaky
 import pytest
 
 from qtpy import QtCore, QtGui, QtWidgets
@@ -34,7 +33,7 @@ def qtconsole(qtbot):
     console.window.close()
 
 
-@flaky(max_runs=3)
+@pytest.mark.flaky(max_runs=3)
 @pytest.mark.parametrize(
     "debug", [True, False])
 def test_scroll(qtconsole, qtbot, debug):
@@ -141,7 +140,7 @@ def test_scroll(qtconsole, qtbot, debug):
     assert scroll_bar.value() > prev_position
 
 
-@flaky(max_runs=3)
+@pytest.mark.flaky(max_runs=3)
 def test_input(qtconsole, qtbot):
     """
     Test input function
@@ -174,7 +173,7 @@ def test_input(qtconsole, qtbot):
     assert 'name: test\ntest' in control.toPlainText()
 
 
-@flaky(max_runs=3)
+@pytest.mark.flaky(max_runs=3)
 def test_debug(qtconsole, qtbot):
     """
     Make sure the cursor works while debugging
@@ -208,7 +207,7 @@ def test_debug(qtconsole, qtbot):
     assert control.toPlainText().strip().split()[-1] == "abcd"
 
 
-@flaky(max_runs=15)
+@pytest.mark.flaky(max_runs=15)
 def test_input_and_print(qtconsole, qtbot):
     """
     Test that we print correctly mixed input and print statements.
@@ -260,7 +259,7 @@ while user_input != '':
     assert output in control.toPlainText()
 
 
-@flaky(max_runs=5)
+@pytest.mark.flaky(max_runs=5)
 @pytest.mark.skipif(os.name == 'nt', reason="no SIGTERM on Windows")
 def test_restart_after_kill(qtconsole, qtbot):
     """

--- a/qtconsole/tests/test_comms.py
+++ b/qtconsole/tests/test_comms.py
@@ -3,7 +3,7 @@ import time
 from queue import Empty
 import unittest
 
-from flaky import flaky
+import pytest
 
 from qtconsole.manager import QtKernelManager
 
@@ -55,7 +55,7 @@ class Tests(unittest.TestCase):
                 pass
         return msg
     
-    @flaky(max_runs=10)
+    @pytest.mark.flaky(max_runs=10)
     def test_kernel_to_frontend(self):
         """Communicate from the kernel to the frontend."""
         comm_manager = self.comm_manager
@@ -109,7 +109,7 @@ class Tests(unittest.TestCase):
         msg = self._get_next_msg()
         assert msg['header']['msg_type'] == 'stream'
 
-    @flaky(max_runs=10)
+    @pytest.mark.flaky(max_runs=10)
     def test_frontend_to_kernel(self):
         """Communicate from the frontend to the kernel."""
         comm_manager = self.comm_manager


### PR DESCRIPTION
Use the `@pytest.mark.flaky` marker in place of the `@flaky.flaky` decorator, to modernize the code and improve compatibility with other plugins providing the feature such as `pytest-rerunfailures`.