### PR TITLE
[WIP] PR: Support IPython 9 theme/colors handling

### DIFF
--- a/qtconsole/ansi_code_processor.py
+++ b/qtconsole/ansi_code_processor.py
@@ -281,6 +281,14 @@ class AnsiCodeProcessor(object):
                 params[:3] = []
         elif code == 49:
             self.background_color = None
+        elif code >= 90 and code <= 97:
+            # Brigth foreground color
+            self.foreground_color = code - 90
+            self.intensity = 1
+        elif code >=100 and code <= 107:
+            # Bright background color
+            self.background_color = code - 100
+            self.intensity = 1
 
         # Recurse with unconsumed parameters.
         self.set_sgr_code(params)


### PR DESCRIPTION
This ensures better support for the theme/colors handling refactor done in IPython 9.x

Related with https://github.com/spyder-ide/spyder-kernels/pull/559

TODO:

* [ ] Add support for bright colors ANSI codes (90-97 and 100-107)
* [ ] Use the new `Theme` definition to set via `%colors` the traceback colors


