### PR TITLE
Drop support for Python 3.8

### DIFF
--- a/.github/workflows/linux-tests.yml
+++ b/.github/workflows/linux-tests.yml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        PYTHON_VERSION: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
+        PYTHON_VERSION: ['3.9', '3.10', '3.11', '3.12', '3.13']
         INSTALL_TYPE: ['conda', 'pip']
         QT_LIB: ['pyqt5', 'pyqt6']
         exclude:

--- a/.github/workflows/macos-tests.yml
+++ b/.github/workflows/macos-tests.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        PYTHON_VERSION: ['3.9', '3.10', '3.11']
+        PYTHON_VERSION: ['3.9', '3.12']
     timeout-minutes: 15
     steps:
       - name: Checkout branch

--- a/.github/workflows/windows-tests.yml
+++ b/.github/workflows/windows-tests.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        PYTHON_VERSION: ['3.9', '3.10', '3.11']
+        PYTHON_VERSION: ['3.9', '3.12']
     timeout-minutes: 15
     steps:
       - name: Checkout branch

--- a/setup.py
+++ b/setup.py
@@ -13,8 +13,8 @@ name = 'qtconsole'
 import sys
 
 v = sys.version_info
-if v[0] >= 3 and v[:2] < (3, 7):
-    error = "ERROR: %s requires Python version 3.8 or above." % name
+if v[0] >= 3 and v[:2] < (3, 8):
+    error = "ERROR: %s requires Python version 3.9 or above." % name
     print(error, file=sys.stderr)
     sys.exit(1)
 
@@ -63,7 +63,7 @@ setup_args = dict(
     license                       = 'BSD',
     platforms                     = "Linux, Mac OS X, Windows",
     keywords                      = ['Interactive', 'Interpreter', 'Shell'],
-    python_requires               = '>= 3.8',
+    python_requires               = '>= 3.9',
     install_requires = [
         'traitlets!=5.2.1,!=5.2.2',
         'jupyter_core',
@@ -90,11 +90,11 @@ setup_args = dict(
         'License :: OSI Approved :: BSD License',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: 3.12',
+        'Programming Language :: Python :: 3.13',
     ],
 )
 


### PR DESCRIPTION
That version reached end-of-life last year.